### PR TITLE
Remove "cc"

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       name="twitter:image"
       content="https://raw.githubusercontent.com/narze/timelapse/master/projects/single-page-svelte_home.png"
     />
-    cc
+    
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
There was a random "cc" in `index.html`. 
I am not sure that it was intentional or not, but this PR has removed it.
![image](https://user-images.githubusercontent.com/28824919/136984761-f67c1780-2f38-437d-9274-cf40774ce531.png)
